### PR TITLE
macOS compatibility

### DIFF
--- a/collect.sh
+++ b/collect.sh
@@ -8,7 +8,7 @@ DBNAME="routermesh.db"
 $SQLITE -line $DBNAME "CREATE TABLE routers(thishop TEXT, nexthop TEXT);"
 
 PREVADDR='0.0.0.0';
-$TRACEROUTE $HOSTNAME | awk '{ if(NR > 1) print $3; }' | sed 's/[(,)]//g' | while read ADDR; do
+$TRACEROUTE $HOSTNAME | grep '^\s*[0-9]\+' | awk '{ if(NR > 1) print $3; }' | sed 's/[(,)]//g' | while read ADDR; do
   echo "$PREVADDR -> $ADDR";
   EXISTS=`$SQLITE $DBNAME "SELECT COUNT(*) FROM routers WHERE thishop='$PREVADDR' AND nexthop='$ADDR'"`
 

--- a/collect.sh
+++ b/collect.sh
@@ -8,7 +8,7 @@ DBNAME="routermesh.db"
 $SQLITE -line $DBNAME "CREATE TABLE routers(thishop TEXT, nexthop TEXT);"
 
 PREVADDR='0.0.0.0';
-$TRACEROUTE $HOSTNAME | grep '^\s*[0-9]\+' | awk '{ if(NR > 1) print $3; }' | sed 's/[(,)]//g' | while read ADDR; do
+$TRACEROUTE $HOSTNAME | grep '^\s*[0-9]\+ ' | awk '{ if(NR > 1) print $3; }' | sed 's/[(,)]//g' | sed 's/[\*]/--/g' | while read ADDR; do
   echo "$PREVADDR -> $ADDR";
   EXISTS=`$SQLITE $DBNAME "SELECT COUNT(*) FROM routers WHERE thishop='$PREVADDR' AND nexthop='$ADDR'"`
 


### PR DESCRIPTION
Eliminate traceroute lines that don't start with a hop number to be compatible with macOS' traceroute.
```bash
 9  prs-bb4-link.telia.net (62.115.124.214)  189.057 ms
    prs-bb3-link.telia.net (62.115.122.4)  202.425 ms
    prs-bb4-link.telia.net (62.115.122.10)  184.615 ms
10  ash-bb4-link.telia.net (62.115.112.242)  209.596 ms  216.946 ms  206.669 ms
11  atl-b22-link.telia.net (62.115.125.191)  161.759 ms
    atl-b22-link.telia.net (62.115.125.128)  168.843 ms
    atl-b22-link.telia.net (62.115.125.191)  155.360 ms
12  jax-b1-link.telia.net (62.115.119.154)  181.273 ms  180.251 ms  181.753 ms
```